### PR TITLE
update SMAPI from 3.14.7 to 3.18.2

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get install -y wget unzip tar strace mono-complete xterm gettext-base jq
 RUN APP_ICON_URL=https://stardewcommunitywiki.com/mediawiki/images/4/48/Fiddlehead_Fern.png && \
     install_app_icon.sh "$APP_ICON_URL"
 
-# Game + ModLoader 1.5.6 3.14.7
+# Game + ModLoader 1.5.6 3.18.2
 RUN mkdir -p /data/Stardew && \
     mkdir -p /data/nexus && \
     wget https://eris.cc/Stardew_latest.tar.gz -qO /data/latest.tar.gz && \
@@ -22,9 +22,9 @@ RUN wget -qO dotnet.tar.gz https://download.visualstudio.microsoft.com/download/
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet 
 
-RUN wget https://github.com/Pathoschild/SMAPI/releases/download/3.14.7/SMAPI-3.14.7-installer.zip -qO /data/nexus.zip && \
+RUN wget https://github.com/Pathoschild/SMAPI/releases/download/3.18.2/SMAPI-3.18.2-installer.zip -qO /data/nexus.zip && \
     unzip /data/nexus.zip -d /data/nexus/ && \
-    /bin/bash -c "SMAPI_NO_TERMINAL=true SMAPI_USE_CURRENT_SHELL=true echo -e \"2\n\n\" | /data/nexus/SMAPI\ 3.14.7\ installer/internal/linux/SMAPI.Installer --install --game-path \"/data/Stardew/Stardew Valley\"" || :
+    /bin/bash -c "SMAPI_NO_TERMINAL=true SMAPI_USE_CURRENT_SHELL=true echo -e \"2\n\n\" | /data/nexus/SMAPI\ 3.18.2\ installer/internal/linux/SMAPI.Installer --install --game-path \"/data/Stardew/Stardew Valley\"" || :
 
 
 # Add Mods & Scripts


### PR DESCRIPTION
Sorry, very big screw up with #22 after renaming branches.

Update SMAPI to latest version 3.18.2 released 09 January 2023 for Stardew Valley 1.5.6.